### PR TITLE
39 管理用問題編集機能の実装

### DIFF
--- a/docs/api/api_v1_openapi.json
+++ b/docs/api/api_v1_openapi.json
@@ -984,6 +984,106 @@
       }
     },
 
+    "/manage/v1/question": {
+      "patch": {
+        "summary": "問題を更新する",
+        "tags": ["ManageAPI"],
+        "parameters": [
+          { "$ref": "#/components/parameters/AuthorizationHeader" },
+          {
+            "in": "query",
+            "name": "questionId",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "問題ID"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "minItems": 1,
+                "properties": {
+                  "title": {
+                    "type": "string",
+                    "description": "問題のタイトル",
+                    "minLength": 1,
+                    "maxLength": 64
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "問題の更新に成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean", "example": true },
+                    "questionId": { "type": "string", "description": "更新した問題ID" }
+                  },
+                  "required": ["success", "questionId"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/manage/v1/question-version": {
+      "patch": {
+        "summary": "問題のアクティブバージョンを更新する",
+        "tags": ["ManageAPI"],
+        "parameters": [
+          { "$ref": "#/components/parameters/AuthorizationHeader" }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "questionId": {
+                    "type": "string",
+                    "description": "問題ID"
+                  },
+                  "version": {
+                    "type": "integer",
+                    "description": "設定するバージョン"
+                  }
+                },
+                "required": ["questionId", "version"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "バージョンの更新に成功",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean", "example": true },
+                    "questionId": { "type": "string", "description": "更新した問題ID" }
+                  },
+                  "required": ["success", "questionId"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/common/v1/recommend-exercise": {
       "get": {
         "summary": "開発者おすすめの問題集を取得する",

--- a/src/app/api/manage/v1/question-version/route.ts
+++ b/src/app/api/manage/v1/question-version/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest } from "next/server"
+import { ApiV1Wrapper } from "@/lib/classes/common/ApiV1Wrapper"
+import { ApiV1Error } from "@/lib/classes/common/ApiV1Error"
+import { prisma } from "@/lib/prisma"
+import { validateBodyWrapper } from "@/lib/functions/validateBodyWrapper"
+import { PrismaQuestionRepository } from "@/lib/classes/repositories/PrismaQuestionRepository"
+import { ManageQuestionService2 } from "@/lib/classes/services/ManageQuestionService2"
+
+export async function PATCH(request: NextRequest) {
+  const api = new ApiV1Wrapper("アクティブバージョン更新")
+
+  return api.execute("PatchManageQuestionVersion", async () => {
+    const { userService } = await api.checkAccessManagePage(request)
+
+    const body = await request.json()
+    const { error, result } = validatePatch(body)
+    if (error) throw error
+
+    const user = await userService.getUserInfo(api.getFirebaseUid())
+    if (!user) throw new ApiV1Error([{ key: "NotFoundError", params: null }])
+
+    const questionRepository = new PrismaQuestionRepository(prisma)
+    const service = new ManageQuestionService2(questionRepository)
+
+    const question = await service.getQuestion(result.questionId)
+    if (!question) throw new ApiV1Error([{ key: "NotFoundError", params: null }])
+
+    const versionEntity = await service.getQuestionVersion(
+      result.questionId,
+      result.version,
+    )
+    if (!versionEntity) {
+      throw new ApiV1Error([{ key: "NotFoundError", params: null }])
+    }
+
+    const access = await userService.accessSchoolMethod(
+      user,
+      question.value.schoolId,
+    )
+    if (!access.includes("edit")) {
+      throw new ApiV1Error([{ key: "RoleTypeError", params: null }])
+    }
+
+    await service.changeCurrentVersion(question, result.version)
+    return { success: true, questionId: result.questionId }
+  })
+}
+
+function validatePatch(body: unknown) {
+  return validateBodyWrapper("PatchManageQuestionVersion", body, (b) => {
+    if (typeof b !== "object" || b === null) {
+      throw new ApiV1Error([
+        { key: "InvalidFormatError", params: { key: "リクエストボディ" } },
+      ])
+    }
+
+    if (!("questionId" in b) || typeof b.questionId !== "string") {
+      throw new ApiV1Error([
+        { key: "RequiredValueError", params: { key: "問題ID" } },
+      ])
+    }
+    if (!("version" in b) || typeof b.version !== "number") {
+      throw new ApiV1Error([
+        { key: "RequiredValueError", params: { key: "バージョン" } },
+      ])
+    }
+  })
+}

--- a/src/app/api/manage/v1/question-version/route.ts
+++ b/src/app/api/manage/v1/question-version/route.ts
@@ -23,7 +23,8 @@ export async function PATCH(request: NextRequest) {
     const service = new ManageQuestionService2(questionRepository)
 
     const question = await service.getQuestion(result.questionId)
-    if (!question) throw new ApiV1Error([{ key: "NotFoundError", params: null }])
+    if (!question)
+      throw new ApiV1Error([{ key: "NotFoundError", params: null }])
 
     const versionEntity = await service.getQuestionVersion(
       result.questionId,
@@ -41,7 +42,7 @@ export async function PATCH(request: NextRequest) {
     }
 
     await service.changeCurrentVersion(question, result.version)
-    return { success: true, questionId: result.questionId }
+    return { questionId: result.questionId }
   })
 }
 

--- a/src/app/api/manage/v1/question-version/route.ts
+++ b/src/app/api/manage/v1/question-version/route.ts
@@ -33,8 +33,7 @@ export async function PATCH(request: NextRequest) {
       throw new ApiV1Error([{ key: "NotFoundError", params: null }])
     }
 
-    const access = await userService.accessSchoolMethod(
-      user,
+    const access = await userService.userController.accessSchoolMethod(
       question.value.schoolId,
     )
     if (!access.includes("edit")) {

--- a/src/app/api/manage/v1/question/route.ts
+++ b/src/app/api/manage/v1/question/route.ts
@@ -91,8 +91,7 @@ export async function PATCH(request: NextRequest) {
     const question = await service.getQuestion(questionId)
     if (!question) throw new ApiV1Error([{ key: "NotFoundError", params: null }])
 
-    const access = await userService.accessSchoolMethod(
-      user,
+    const access = await userService.userController.accessSchoolMethod(
       question.value.schoolId,
     )
     if (!access.includes("edit")) {

--- a/src/app/api/manage/v1/question/route.ts
+++ b/src/app/api/manage/v1/question/route.ts
@@ -89,7 +89,8 @@ export async function PATCH(request: NextRequest) {
     const service = new ManageQuestionService2(questionRepository)
 
     const question = await service.getQuestion(questionId)
-    if (!question) throw new ApiV1Error([{ key: "NotFoundError", params: null }])
+    if (!question)
+      throw new ApiV1Error([{ key: "NotFoundError", params: null }])
 
     const access = await userService.userController.accessSchoolMethod(
       question.value.schoolId,
@@ -99,7 +100,7 @@ export async function PATCH(request: NextRequest) {
     }
 
     await service.editQuestion(question, { title: result.title! })
-    return { success: true, questionId }
+    return { questionId }
   })
 }
 

--- a/src/app/api/manage/v1/question/route.ts
+++ b/src/app/api/manage/v1/question/route.ts
@@ -2,6 +2,9 @@ import { NextRequest } from "next/server"
 import { prisma } from "@/lib/prisma"
 import { ApiV1Error } from "@/lib/classes/common/ApiV1Error"
 import { ApiV1Wrapper } from "@/lib/classes/common/ApiV1Wrapper"
+import { validateBodyWrapper } from "@/lib/functions/validateBodyWrapper"
+import { PrismaQuestionRepository } from "@/lib/classes/repositories/PrismaQuestionRepository"
+import { ManageQuestionService2 } from "@/lib/classes/services/ManageQuestionService2"
 import { ManageQuestionService } from "@/lib/classes/services/ManageQuestionService"
 
 export async function GET(request: NextRequest) {
@@ -63,36 +66,66 @@ export async function GET(request: NextRequest) {
   })
 }
 
-// export async function PATCH(request: NextRequest) {
-//   const api = new ApiV1Wrapper("管理用問題集の更新")
+export async function PATCH(request: NextRequest) {
+  const api = new ApiV1Wrapper("管理用問題の更新")
 
-//   return await api.execute("PatchManageExercise", async () => {
-//     const { userService } = await api.checkAccessManagePage(request)
+  return api.execute("PatchManageQuestion", async () => {
+    const { userService } = await api.checkAccessManagePage(request)
 
-//     const exerciseId = request.nextUrl.searchParams.get("exerciseId")
-//     if (!exerciseId || exerciseId.length < 2)
-//       throw new ApiV1Error([
-//         { key: "RequiredValueError", params: { key: "問題集ID" } },
-//       ])
+    const questionId = request.nextUrl.searchParams.get("questionId")
+    if (!questionId)
+      throw new ApiV1Error([
+        { key: "RequiredValueError", params: { key: "問題ID" } },
+      ])
 
-//     const body = await request.json()
-//     const { error, result: resultBody } = validatePatch(body)
+    const body = await request.json()
+    const { error, result } = validatePatch(body)
+    if (error) throw error
 
-//     if (error) throw error
+    const user = await userService.getUserInfo(api.getFirebaseUid())
+    if (!user) throw new ApiV1Error([{ key: "NotFoundError", params: null }])
 
-//     const exerciseService = new ExerciseService(prisma)
-//     exerciseService.setUserController(userService.userController)
+    const questionRepository = new PrismaQuestionRepository(prisma)
+    const service = new ManageQuestionService2(questionRepository)
 
-//     const result = await exerciseService.updateExercise(exerciseId, resultBody)
+    const question = await service.getQuestion(questionId)
+    if (!question) throw new ApiV1Error([{ key: "NotFoundError", params: null }])
 
-//     return {
-//       exercise: {
-//         exerciseId: result.id,
-//         title: result.title,
-//         description: result.description,
-//         createdAt: result.createdAt.toISOString(),
-//         updatedAt: result.updatedAt.toISOString(),
-//       },
-//     }
-//   })
-// }
+    const access = await userService.accessSchoolMethod(
+      user,
+      question.value.schoolId,
+    )
+    if (!access.includes("edit")) {
+      throw new ApiV1Error([{ key: "RoleTypeError", params: null }])
+    }
+
+    await service.editQuestion(question, { title: result.title! })
+    return { success: true, questionId }
+  })
+}
+
+function validatePatch(body: unknown) {
+  return validateBodyWrapper("PatchManageQuestion", body, (b) => {
+    if (typeof b !== "object" || b === null) {
+      throw new ApiV1Error([
+        { key: "InvalidFormatError", params: { key: "リクエストボディ" } },
+      ])
+    }
+
+    if (!("title" in b)) {
+      throw new ApiV1Error([
+        { key: "RequiredValueError", params: { key: "問題タイトル" } },
+      ])
+    }
+
+    if (
+      typeof b.title !== "string" ||
+      b.title.length < 1 ||
+      b.title.length > 64
+    ) {
+      throw new ApiV1Error([
+        { key: "InvalidFormatError", params: { key: "問題タイトル" } },
+      ])
+    }
+  })
+}

--- a/src/lib/classes/entities/QuestionEntity.ts
+++ b/src/lib/classes/entities/QuestionEntity.ts
@@ -1,0 +1,38 @@
+import { EntityMutable } from "@/lib/interfaces/EntityMutable"
+import { STATICS } from "@/lib/statics"
+import {
+  QuestionAnswerTypeType,
+  QuestionTypeType,
+} from "@/lib/types/base/questionTypes"
+import { ApiV1Error } from "../common/ApiV1Error"
+
+export type QuestionEntityType = {
+  questionId: string
+  schoolId: string
+  title: string
+  questionType: QuestionTypeType
+  answerType: QuestionAnswerTypeType
+  currentVersion: number | null
+  draftVersion: number | null
+  isPublished: boolean
+  createdAt: Date
+  updatedAt: Date
+  deletedAt: Date | null
+}
+
+export class QuestionEntity extends EntityMutable<QuestionEntityType> {
+  constructor(value: QuestionEntityType) {
+    super(value)
+  }
+
+  public validate() {
+    if (
+      this.value.title.length < STATICS.VALIDATE.QUESTION_TITLE.MIN_LENGTH ||
+      this.value.title.length > STATICS.VALIDATE.QUESTION_TITLE.MAX_LENGTH
+    ) {
+      throw new ApiV1Error([
+        { key: "InvalidFormatError", params: { key: "問題タイトル" } },
+      ])
+    }
+  }
+}

--- a/src/lib/classes/entities/QuestionVersionEntity.ts
+++ b/src/lib/classes/entities/QuestionVersionEntity.ts
@@ -1,0 +1,17 @@
+import { EntityMutable } from "@/lib/interfaces/EntityMutable"
+
+
+export type QuestionVersionEntityType = {
+  questionId: string
+  version: number
+  content: string
+  hint: string
+}
+
+export class QuestionVersionEntity extends EntityMutable<QuestionVersionEntityType> {
+  constructor(value: QuestionVersionEntityType) {
+    super(value)
+  }
+
+  public validate() {}
+}

--- a/src/lib/classes/repositories/PrismaQuestionRepository.ts
+++ b/src/lib/classes/repositories/PrismaQuestionRepository.ts
@@ -1,0 +1,68 @@
+import { IQuestionRepository } from "@/lib/interfaces/IQuestionRepository"
+import { RepositoryBase } from "../common/RepositoryBase"
+import { QuestionEntity } from "../entities/QuestionEntity"
+import { QuestionVersionEntity } from "../entities/QuestionVersionEntity"
+
+export class PrismaQuestionRepository
+  extends RepositoryBase
+  implements IQuestionRepository
+{
+  async findById(questionId: string): Promise<QuestionEntity | null> {
+    const q = await this.dbConnection.question.findUnique({
+      where: { id: questionId },
+    })
+    if (!q) return null
+    return new QuestionEntity({
+      questionId: q.id,
+      schoolId: q.schoolId,
+      title: q.title,
+      questionType: q.questionType,
+      answerType: q.answerType,
+      currentVersion: q.currentVersionId,
+      draftVersion: q.draftVersionId,
+      isPublished: q.isPublished,
+      createdAt: q.createdAt,
+      updatedAt: q.updatedAt,
+      deletedAt: q.deletedAt,
+    })
+  }
+
+  async findVersion(
+    questionId: string,
+    version: number,
+  ): Promise<QuestionVersionEntity | null> {
+    const v = await this.dbConnection.questionVersion.findUnique({
+      where: { questionId_version: { questionId, version } },
+    })
+    if (!v) return null
+    return new QuestionVersionEntity({
+      questionId: v.questionId,
+      version: v.version,
+      content: v.content,
+      hint: v.hint,
+    })
+  }
+
+  async save(question: QuestionEntity): Promise<QuestionEntity> {
+    const q = await this.dbConnection.question.update({
+      where: { id: question.value.questionId },
+      data: {
+        title: question.value.title,
+        currentVersionId: question.value.currentVersion,
+      },
+    })
+    return new QuestionEntity({
+      questionId: q.id,
+      schoolId: q.schoolId,
+      title: q.title,
+      questionType: q.questionType,
+      answerType: q.answerType,
+      currentVersion: q.currentVersionId,
+      draftVersion: q.draftVersionId,
+      isPublished: q.isPublished,
+      createdAt: q.createdAt,
+      updatedAt: q.updatedAt,
+      deletedAt: q.deletedAt,
+    })
+  }
+}

--- a/src/lib/classes/services/ManageQuestionService2.ts
+++ b/src/lib/classes/services/ManageQuestionService2.ts
@@ -1,0 +1,41 @@
+import { IQuestionRepository } from "@/lib/interfaces/IQuestionRepository"
+import { QuestionEntity } from "../entities/QuestionEntity"
+import { QuestionVersionEntity } from "../entities/QuestionVersionEntity"
+
+export class ManageQuestionService2 {
+  constructor(private readonly _questionRepository: IQuestionRepository) {}
+
+  async getQuestion(questionId: string): Promise<QuestionEntity | null> {
+    return this._questionRepository.findById(questionId)
+  }
+
+  async getQuestionVersion(
+    questionId: string,
+    version: number,
+  ): Promise<QuestionVersionEntity | null> {
+    return this._questionRepository.findVersion(questionId, version)
+  }
+
+  async editQuestion(
+    question: QuestionEntity,
+    data: { title: string },
+  ): Promise<QuestionEntity> {
+    const newQuestion = new QuestionEntity({
+      ...question.value,
+      title: data.title,
+    })
+    newQuestion.validate()
+    return this._questionRepository.save(newQuestion)
+  }
+
+  async changeCurrentVersion(
+    question: QuestionEntity,
+    version: number,
+  ): Promise<QuestionEntity> {
+    const newQuestion = new QuestionEntity({
+      ...question.value,
+      currentVersion: version,
+    })
+    return this._questionRepository.save(newQuestion)
+  }
+}

--- a/src/lib/interfaces/IQuestionRepository.ts
+++ b/src/lib/interfaces/IQuestionRepository.ts
@@ -1,0 +1,11 @@
+import { QuestionEntity } from "../classes/entities/QuestionEntity"
+import { QuestionVersionEntity } from "../classes/entities/QuestionVersionEntity"
+
+export interface IQuestionRepository {
+  findById(questionId: string): Promise<QuestionEntity | null>
+  findVersion(
+    questionId: string,
+    version: number,
+  ): Promise<QuestionVersionEntity | null>
+  save(question: QuestionEntity): Promise<QuestionEntity>
+}

--- a/src/lib/types/apiV1Types.ts
+++ b/src/lib/types/apiV1Types.ts
@@ -432,12 +432,10 @@ export type ApiV1OutTypeMap = {
   }
 
   PatchManageQuestion: {
-    success: boolean
     questionId: string
   }
 
   PatchManageQuestionVersion: {
-    success: boolean
     questionId: string
   }
 

--- a/src/lib/types/apiV1Types.ts
+++ b/src/lib/types/apiV1Types.ts
@@ -182,6 +182,14 @@ export type ApiV1InTypeMap = {
   }
 
   /**
+   * PATCH /api/manage/v1/question-version
+   */
+  PatchManageQuestionVersion: {
+    questionId: string
+    version: number
+  }
+
+  /**
    * GET /api/user/v1/exercise?exerciseId=xxxx
    */
   GetUserExerciseInfo: {
@@ -420,6 +428,16 @@ export type ApiV1OutTypeMap = {
    * POST /api/manage/v1/exercise/question
    */
   PostManageExerciseQuestion: {
+    questionId: string
+  }
+
+  PatchManageQuestion: {
+    success: boolean
+    questionId: string
+  }
+
+  PatchManageQuestionVersion: {
+    success: boolean
     questionId: string
   }
 

--- a/src/tests/api/ManageV1Question.test.ts
+++ b/src/tests/api/ManageV1Question.test.ts
@@ -2,7 +2,8 @@
  * @jest-environment node
  */
 
-import { GET } from "@/app/api/manage/v1/question/route"
+import { GET, PATCH } from "@/app/api/manage/v1/question/route"
+import { PATCH as PATCH_VERSION } from "@/app/api/manage/v1/question-version/route"
 import { TestUtility } from "@/tests/TestUtility"
 
 const AdminUserEmail = "kaitopia-admin+001@kaitopia.com"
@@ -98,6 +99,90 @@ describe("API /api/manage/v1/question", () => {
             message: "アクセス権限がありません",
           },
         ]),
+      })
+    })
+
+    describe("PATCH", () => {
+      test("ADMINユーザ 問題のタイトルを更新できる", async () => {
+        const result = await TestUtility.runApi(
+          PATCH,
+          "PATCH",
+          "/api/manage/v1/question?questionId=intro_programming_1_1",
+          { Authorization: `Bearer ${token}` },
+          { title: "更新タイトル" },
+        )
+        expect(result.ok).toBe(true)
+        expect(result.status).toBe(200)
+        const json = await result.json()
+        expect(json).toEqual({
+          success: true,
+          questionId: "intro_programming_1_1",
+        })
+      })
+
+      test("USERユーザ 問題のタイトルを更新できない", async () => {
+        const userToken = await TestUtility.getTokenByEmailAndLogin(
+          UserUserEmail,
+          UserUserPassword,
+        )
+        const result = await TestUtility.runApi(
+          PATCH,
+          "PATCH",
+          "/api/manage/v1/question?questionId=intro_programming_1_1",
+          { Authorization: `Bearer ${userToken}` },
+          { title: "更新タイトル" },
+        )
+        expect(result.ok).toBe(false)
+        expect(result.status).toBe(403)
+        const json = await result.json()
+        expect(json).toEqual({
+          success: false,
+          errors: expect.arrayContaining([
+            { code: "RoleTypeError", message: "アクセス権限がありません" },
+          ]),
+        })
+      })
+    })
+
+    describe("PATCH version", () => {
+      test("ADMINユーザ アクティブバージョンを更新できる", async () => {
+        const result = await TestUtility.runApi(
+          PATCH_VERSION,
+          "PATCH",
+          "/api/manage/v1/question-version",
+          { Authorization: `Bearer ${token}` },
+          { questionId: "intro_programming_1_1", version: 1 },
+        )
+        expect(result.ok).toBe(true)
+        expect(result.status).toBe(200)
+        const json = await result.json()
+        expect(json).toEqual({
+          success: true,
+          questionId: "intro_programming_1_1",
+        })
+      })
+
+      test("USERユーザ アクティブバージョンを更新できない", async () => {
+        const userToken = await TestUtility.getTokenByEmailAndLogin(
+          UserUserEmail,
+          UserUserPassword,
+        )
+        const result = await TestUtility.runApi(
+          PATCH_VERSION,
+          "PATCH",
+          "/api/manage/v1/question-version",
+          { Authorization: `Bearer ${userToken}` },
+          { questionId: "intro_programming_1_1", version: 1 },
+        )
+        expect(result.ok).toBe(false)
+        expect(result.status).toBe(403)
+        const json = await result.json()
+        expect(json).toEqual({
+          success: false,
+          errors: expect.arrayContaining([
+            { code: "RoleTypeError", message: "アクセス権限がありません" },
+          ]),
+        })
       })
     })
   })

--- a/src/tests/api/ManageV1Question.test.ts
+++ b/src/tests/api/ManageV1Question.test.ts
@@ -109,14 +109,16 @@ describe("API /api/manage/v1/question", () => {
           "PATCH",
           "/api/manage/v1/question?questionId=intro_programming_1_1",
           { Authorization: `Bearer ${token}` },
-          { title: "更新タイトル" },
+          { title: "プログラミング入門 「プログラム」とは？" },
         )
         expect(result.ok).toBe(true)
         expect(result.status).toBe(200)
         const json = await result.json()
         expect(json).toEqual({
           success: true,
-          questionId: "intro_programming_1_1",
+          data: {
+            questionId: "intro_programming_1_1",
+          },
         })
       })
 
@@ -158,7 +160,9 @@ describe("API /api/manage/v1/question", () => {
         const json = await result.json()
         expect(json).toEqual({
           success: true,
-          questionId: "intro_programming_1_1",
+          data: {
+            questionId: "intro_programming_1_1",
+          },
         })
       })
 


### PR DESCRIPTION
## Summary
- ManageQuestionService2を改修し、アクセス権限の確認をAPI側で行うよう変更
- QuestionVersionEntityにローカルタイプを追加
- 管理APIのPATCH処理を更新してquestionIdを返却
- `/manage/v1/question-version` APIも同様に修正
- OpenAPIドキュメントとテストケースを更新

## Testing
- `npm run lint`
- `npm run test` *(failed: PrismaClientInitializationError)*

------
https://chatgpt.com/codex/tasks/task_e_6855ee07a48c833084bd8219fd28aa58