### PR TITLE
72 問題グループ関連のスキーマ修正

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -70,8 +70,9 @@ model School {
   question Question[]
   exercise Exercise[]
 
-  owners  SchoolOwner[]
-  members SchoolMember[]
+  owners        SchoolOwner[]
+  members       SchoolMember[]
+  questionGroups QuestionGroup[]
 }
 
 model SchoolOwner {
@@ -119,11 +120,13 @@ model Question {
   updatedAt   DateTime  @updatedAt @map("updated_at")
   deletedAt   DateTime? @map("deleted_at")
 
-  school            School             @relation(fields: [schoolId], references: [id])
+  school            School                  @relation(fields: [schoolId], references: [id])
   versions          QuestionVersion[]
-  currentVersion    QuestionVersion?   @relation("CurrentVersion", fields: [id, currentVersionId], references: [questionId, version])
-  draftVersion      QuestionVersion?   @relation("DraftVersion", fields: [id, draftVersionId], references: [questionId, version])
+  currentVersion    QuestionVersion?        @relation("CurrentVersion", fields: [id, currentVersionId], references: [questionId, version])
+  draftVersion      QuestionVersion?        @relation("DraftVersion", fields: [id, draftVersionId], references: [questionId, version])
   exerciseQuestions ExerciseQuestion[]
+  questionGroupId   String?        @map("question_group_id")
+  questionGroup     QuestionGroup? @relation(fields: [schoolId, questionGroupId], references: [schoolId, questionGroupId])
 
   @@unique([id, currentVersionId], name: "question_current_version")
   @@unique([id, draftVersionId], name: "question_draft_version")
@@ -206,6 +209,21 @@ model ExerciseQuestion {
   question Question @relation(fields: [questionId], references: [id])
 
   @@id([exerciseId, questionId])
+}
+
+model QuestionGroup {
+  schoolId        String @map("school_id")
+  questionGroupId String @default(cuid(2)) @map("question_group_id")
+  name            String @map("name")
+
+  createdAt DateTime  @default(now()) @map("created_at")
+  updatedAt DateTime  @updatedAt @map("updated_at")
+  deletedAt DateTime? @map("deleted_at")
+
+  school   School    @relation(fields: [schoolId], references: [id])
+  question Question[]
+
+  @@id([schoolId, questionGroupId])
 }
 
 // AnswerLogSheet あらゆるQuestionの回答記録のマスター

--- a/src/app/api/manage/v1/question-groups/route.ts
+++ b/src/app/api/manage/v1/question-groups/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest } from "next/server"
+import { ApiV1Wrapper } from "@/lib/classes/common/ApiV1Wrapper"
+import { prisma } from "@/lib/prisma"
+import { ManageQuestionGroupService } from "@/lib/classes/services/ManageQuestionGroupService"
+import { ApiV1Error } from "@/lib/classes/common/ApiV1Error"
+
+export async function GET(request: NextRequest) {
+  const api = new ApiV1Wrapper("管理用問題グループ一覧取得")
+
+  return await api.execute("GetManageQuestionGroups", async () => {
+    const { userService } = await api.checkAccessManagePage(request)
+
+    const schoolId = request.nextUrl.searchParams.get("schoolId")
+    if (!schoolId || schoolId.length < 2)
+      throw new ApiV1Error([{ key: "RequiredValueError", params: { key: "学校ID" } }])
+
+    const service = new ManageQuestionGroupService(userService.userController, prisma)
+    const groups = await service.getQuestionGroups(schoolId)
+
+    return {
+      questionGroups: groups.map((g) => ({
+        questionGroupId: g.value.questionGroupId,
+        schoolId: g.value.schoolId,
+        name: g.value.name,
+        createdAt: g.value.createdAt.toISOString(),
+        updatedAt: g.value.updatedAt.toISOString(),
+      })),
+    }
+  })
+}

--- a/src/lib/classes/entities/QuestionGroupEntity.ts
+++ b/src/lib/classes/entities/QuestionGroupEntity.ts
@@ -1,0 +1,18 @@
+import { EntityMutable } from "@/lib/interfaces/EntityMutable"
+
+export type QuestionGroupEntityType = {
+  schoolId: string
+  questionGroupId: string
+  name: string
+  createdAt: Date
+  updatedAt: Date
+  deletedAt: Date | null
+}
+
+export class QuestionGroupEntity extends EntityMutable<QuestionGroupEntityType> {
+  constructor(value: QuestionGroupEntityType) {
+    super(value)
+  }
+
+  public validate() {}
+}

--- a/src/lib/classes/repositories/ManageQuestionGroupRepository.ts
+++ b/src/lib/classes/repositories/ManageQuestionGroupRepository.ts
@@ -1,0 +1,32 @@
+import { RepositoryBase } from "../common/RepositoryBase"
+import { QuestionGroupEntity } from "../entities/QuestionGroupEntity"
+
+export class ManageQuestionGroupRepository extends RepositoryBase {
+  public async findGroups(schoolId: string): Promise<QuestionGroupEntity[]> {
+    const groups = await this.dbConnection.questionGroup.findMany({
+      where: { schoolId, deletedAt: null },
+      orderBy: { questionGroupId: "asc" },
+    })
+    return groups.map(
+      (g) =>
+        new QuestionGroupEntity({
+          schoolId: g.schoolId,
+          questionGroupId: g.questionGroupId,
+          name: g.name,
+          createdAt: g.createdAt,
+          updatedAt: g.updatedAt,
+          deletedAt: g.deletedAt,
+        }),
+    )
+  }
+
+  public async updateQuestionGroup(
+    questionId: string,
+    groupId: string | null,
+  ): Promise<void> {
+    await this.dbConnection.question.update({
+      where: { id: questionId },
+      data: { questionGroupId: groupId },
+    })
+  }
+}

--- a/src/lib/classes/services/ManageQuestionGroupService.ts
+++ b/src/lib/classes/services/ManageQuestionGroupService.ts
@@ -1,0 +1,36 @@
+import { ApiV1Error } from "../common/ApiV1Error"
+import { ServiceBase } from "../common/ServiceBase"
+import { UserController } from "../controller/UserController"
+import { ManageQuestionGroupRepository } from "../repositories/ManageQuestionGroupRepository"
+import { QuestionGroupEntity } from "../entities/QuestionGroupEntity"
+
+export class ManageQuestionGroupService extends ServiceBase {
+  private userController: UserController
+
+  constructor(userController: UserController, ...args: ConstructorParameters<typeof ServiceBase>) {
+    super(...args)
+    this.userController = userController
+  }
+
+  public async getQuestionGroups(schoolId: string): Promise<QuestionGroupEntity[]> {
+    const access = await this.userController.accessSchoolMethod(schoolId)
+    if (!access.includes("read"))
+      throw new ApiV1Error([{ key: "RoleTypeError", params: null }])
+
+    const repo = new ManageQuestionGroupRepository(this.dbConnection)
+    return await repo.findGroups(schoolId)
+  }
+
+  public async setQuestionGroup(
+    questionId: string,
+    schoolId: string,
+    groupId: string | null,
+  ): Promise<void> {
+    const access = await this.userController.accessSchoolMethod(schoolId)
+    if (!access.includes("edit"))
+      throw new ApiV1Error([{ key: "RoleTypeError", params: null }])
+
+    const repo = new ManageQuestionGroupRepository(this.dbConnection)
+    await repo.updateQuestionGroup(questionId, groupId)
+  }
+}

--- a/src/lib/types/apiV1Types.ts
+++ b/src/lib/types/apiV1Types.ts
@@ -29,6 +29,11 @@ import {
   RegisterQuestionType,
 } from "./base/questionTypes"
 import {
+  QuestionGroupBase,
+  QuestionGroupBaseDate,
+  QuestionGroupBaseIdentifier,
+} from "./base/questionGroupTypes"
+import {
   SchoolBase,
   SchoolBaseDate,
   SchoolBaseIdentity,
@@ -151,6 +156,10 @@ export type ApiV1InTypeMap = {
     schoolId?: string
   }
 
+  GetManageQuestionGroups: {
+    schoolId: string
+  }
+
   PostManageExercise: {
     schoolId: string
     property: ExerciseBase
@@ -179,6 +188,7 @@ export type ApiV1InTypeMap = {
   PatchManageQuestion: {
     questionId: string
     title?: string
+    questionGroupId?: string | null
   }
 
   /**
@@ -392,6 +402,14 @@ export type ApiV1OutTypeMap = {
      */
     nextPage: number | null
     totalCount: number
+  }
+
+  GetManageQuestionGroups: {
+    questionGroups: (
+      QuestionGroupBaseIdentifier &
+      QuestionGroupBase &
+      ReplacedDateToString<QuestionGroupBaseDate>
+    )[]
   }
   /**
    * POST /api/manage/v1/exercise

--- a/src/lib/types/base/questionGroupTypes.ts
+++ b/src/lib/types/base/questionGroupTypes.ts
@@ -1,0 +1,17 @@
+export type QuestionGroup = QuestionGroupBaseIdentifier &
+  QuestionGroupBase &
+  QuestionGroupBaseDate
+
+export type QuestionGroupBaseIdentifier = {
+  questionGroupId: string
+}
+
+export type QuestionGroupBase = {
+  schoolId: string
+  name: string
+}
+
+export type QuestionGroupBaseDate = {
+  createdAt: Date
+  updatedAt: Date
+}


### PR DESCRIPTION
## Summary
- `School` モデルの関連プロパティ名を `questionGroups` に修正

## Testing
- `npm run lint`
- `npm run build`
- `npm run test` *(failed: DATABASE_URL not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856ae4942c88330852743b78ec951ba