### PR TITLE
148 Firebase認証情報をAuthProviderに分離

### DIFF
--- a/prisma/schema/authProvider.prisma
+++ b/prisma/schema/authProvider.prisma
@@ -1,0 +1,16 @@
+enum AuthProviderType {
+  FIREBASE_GUEST
+  FIREBASE_EMAIL
+}
+
+model AuthProvider {
+  id          String           @id @default(cuid(2))
+  user        User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId      String           @map("user_id")
+  providerType AuthProviderType @map("provider_type")
+  providerUid  String           @map("provider_uid")
+  createdAt    DateTime         @default(now()) @map("created_at")
+  updatedAt    DateTime         @updatedAt @map("updated_at")
+
+  @@unique([providerUid, providerType])
+}

--- a/prisma/schema/migrations/20250801000000_add_auth_provider/migration.sql
+++ b/prisma/schema/migrations/20250801000000_add_auth_provider/migration.sql
@@ -1,0 +1,22 @@
+-- CreateEnum
+CREATE TYPE "AuthProviderType" AS ENUM ('FIREBASE_GUEST', 'FIREBASE_EMAIL');
+
+-- CreateTable
+CREATE TABLE "AuthProvider" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "provider_type" "AuthProviderType" NOT NULL,
+    "provider_uid" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AuthProvider_provider_uid_provider_type_key" ON "AuthProvider"("provider_uid", "provider_type");
+
+-- AddForeignKey
+ALTER TABLE "AuthProvider" ADD CONSTRAINT "AuthProvider_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "firebase_uid";
+ALTER TABLE "User" DROP COLUMN "is_guest";

--- a/prisma/schema/user.prisma
+++ b/prisma/schema/user.prisma
@@ -1,9 +1,6 @@
 model User {
   id String @id @default(cuid(2))
 
-  firebaseUid String  @unique @map("firebase_uid")
-  isGuest     Boolean @default(false) @map("is_guest")
-
   role Role @default(USER) @map("role")
 
   name         String    @map("name")
@@ -18,6 +15,7 @@ model User {
   ownerSchools  SchoolOwner[]
   memberSchools SchoolMember[]
   userHistories UserHistory[]
+  authProviders AuthProvider[]
 }
 
 enum Role {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -52,19 +52,33 @@ async function transferUsers(db: Prisma.TransactionClient) {
     data: [
       {
         id: "kaitopia-user+001",
-        firebaseUid: "3na1wqgfg7Jj71amJifrwGrCtkCg",
         name: "Kaitopia User 001",
         email: "kaitopia-user+001@kaitopia.com",
-        isGuest: false,
         role: "USER",
       },
       {
         id: "kaitopia-admin+001",
-        firebaseUid: "SgOxbbAadPt2Ii0hwjsuVPLrnPH3",
         name: "Kaitopia Admin 001",
         email: "kaitopia-admin+001@kaitopia.com",
-        isGuest: false,
         role: "ADMIN",
+      },
+    ],
+  })
+
+  await db.authProvider.createMany({
+    skipDuplicates: true,
+    data: [
+      {
+        id: "auth-kaitopia-user+001",
+        userId: "kaitopia-user+001",
+        providerUid: "3na1wqgfg7Jj71amJifrwGrCtkCg",
+        providerType: "FIREBASE_EMAIL",
+      },
+      {
+        id: "auth-kaitopia-admin+001",
+        userId: "kaitopia-admin+001",
+        providerUid: "SgOxbbAadPt2Ii0hwjsuVPLrnPH3",
+        providerType: "FIREBASE_EMAIL",
       },
     ],
   })

--- a/src/app/api/manage/v1/dashboard/route.ts
+++ b/src/app/api/manage/v1/dashboard/route.ts
@@ -22,7 +22,7 @@ export async function GET(req: NextRequest) {
       new PrismaSchoolRepository(prisma),
     )
     const user = await userService.getUserInfo(
-      api.getFirebaseUid(),
+      api.getProviderUid(),
       api.getProviderType()!,
     )
     if (!user) {

--- a/src/app/api/manage/v1/dashboard/route.ts
+++ b/src/app/api/manage/v1/dashboard/route.ts
@@ -21,7 +21,10 @@ export async function GET(req: NextRequest) {
       new PrismaUserRepository(prisma),
       new PrismaSchoolRepository(prisma),
     )
-    const user = await userService.getUserInfo(api.getFirebaseUid())
+    const user = await userService.getUserInfo(
+      api.getFirebaseUid(),
+      api.getProviderType()!,
+    )
     if (!user) {
       throw new ApiV1Error([
         {

--- a/src/app/api/manage/v1/exercise/question/route.ts
+++ b/src/app/api/manage/v1/exercise/question/route.ts
@@ -38,7 +38,10 @@ export async function GET(request: NextRequest) {
       new PrismaUserRepository(prisma),
       new PrismaSchoolRepository(prisma),
     )
-    const user = await userService2.getUserInfo(api.getFirebaseUid())
+    const user = await userService2.getUserInfo(
+      api.getFirebaseUid(),
+      api.getProviderType()!,
+    )
     if (!user)
       throw new ApiV1Error([{ key: "AuthenticationError", params: null }])
 
@@ -83,14 +86,20 @@ export async function POST(request: NextRequest) {
     if (validateResult.error) throw validateResult.error
 
     const userService = new UserService(prisma)
-    await userService.getUserInfo(api.getFirebaseUid())
+    await userService.getUserInfo(
+      api.getFirebaseUid(),
+      api.getProviderType()!,
+    )
 
     const userService2 = new UserService2(
       prisma,
       new PrismaUserRepository(prisma),
       new PrismaSchoolRepository(prisma),
     )
-    const user = await userService2.getUserInfo(api.getFirebaseUid())
+    const user = await userService2.getUserInfo(
+      api.getFirebaseUid(),
+      api.getProviderType()!,
+    )
     if (!user)
       throw new ApiV1Error([{ key: "AuthenticationError", params: null }])
 

--- a/src/app/api/manage/v1/exercise/question/route.ts
+++ b/src/app/api/manage/v1/exercise/question/route.ts
@@ -39,7 +39,7 @@ export async function GET(request: NextRequest) {
       new PrismaSchoolRepository(prisma),
     )
     const user = await userService2.getUserInfo(
-      api.getFirebaseUid(),
+      api.getProviderUid(),
       api.getProviderType()!,
     )
     if (!user)
@@ -87,7 +87,7 @@ export async function POST(request: NextRequest) {
 
     const userService = new UserService(prisma)
     await userService.getUserInfo(
-      api.getFirebaseUid(),
+      api.getProviderUid(),
       api.getProviderType()!,
     )
 
@@ -97,7 +97,7 @@ export async function POST(request: NextRequest) {
       new PrismaSchoolRepository(prisma),
     )
     const user = await userService2.getUserInfo(
-      api.getFirebaseUid(),
+      api.getProviderUid(),
       api.getProviderType()!,
     )
     if (!user)

--- a/src/app/api/manage/v1/question-groups/route.ts
+++ b/src/app/api/manage/v1/question-groups/route.ts
@@ -24,7 +24,10 @@ export async function GET(request: NextRequest) {
       new PrismaUserRepository(prisma),
       new PrismaSchoolRepository(prisma),
     )
-    const user = await userService.getUserInfo(api.getFirebaseUid())
+    const user = await userService.getUserInfo(
+      api.getFirebaseUid(),
+      api.getProviderType()!,
+    )
     if (!user)
       throw new ApiV1Error([{ key: "AuthenticationError", params: null }])
 

--- a/src/app/api/manage/v1/question-groups/route.ts
+++ b/src/app/api/manage/v1/question-groups/route.ts
@@ -25,7 +25,7 @@ export async function GET(request: NextRequest) {
       new PrismaSchoolRepository(prisma),
     )
     const user = await userService.getUserInfo(
-      api.getFirebaseUid(),
+      api.getProviderUid(),
       api.getProviderType()!,
     )
     if (!user)

--- a/src/app/api/manage/v1/question-version/route.ts
+++ b/src/app/api/manage/v1/question-version/route.ts
@@ -25,7 +25,7 @@ export async function PATCH(request: NextRequest) {
       new PrismaSchoolRepository(prisma),
     )
     const user = await userService2.getUserInfo(
-      api.getFirebaseUid(),
+      api.getProviderUid(),
       api.getProviderType()!,
     )
     if (!user) throw new ApiV1Error([{ key: "NotFoundError", params: null }])

--- a/src/app/api/manage/v1/question-version/route.ts
+++ b/src/app/api/manage/v1/question-version/route.ts
@@ -24,7 +24,10 @@ export async function PATCH(request: NextRequest) {
       new PrismaUserRepository(prisma),
       new PrismaSchoolRepository(prisma),
     )
-    const user = await userService2.getUserInfo(api.getFirebaseUid())
+    const user = await userService2.getUserInfo(
+      api.getFirebaseUid(),
+      api.getProviderType()!,
+    )
     if (!user) throw new ApiV1Error([{ key: "NotFoundError", params: null }])
 
     const questionRepository = new PrismaQuestionRepository(prisma)

--- a/src/app/api/manage/v1/question/route.ts
+++ b/src/app/api/manage/v1/question/route.ts
@@ -27,7 +27,10 @@ export async function GET(request: NextRequest) {
       new PrismaUserRepository(prisma),
       new PrismaSchoolRepository(prisma),
     )
-    const user = await userService2.getUserInfo(api.getFirebaseUid())
+    const user = await userService2.getUserInfo(
+      api.getFirebaseUid(),
+      api.getProviderType()!,
+    )
     if (!user)
       throw new ApiV1Error([{ key: "AuthenticationError", params: null }])
 
@@ -87,7 +90,10 @@ export async function PATCH(request: NextRequest) {
       new PrismaUserRepository(prisma),
       new PrismaSchoolRepository(prisma),
     )
-    const user = await userService2.getUserInfo(api.getFirebaseUid())
+    const user = await userService2.getUserInfo(
+      api.getFirebaseUid(),
+      api.getProviderType()!,
+    )
     if (!user) throw new ApiV1Error([{ key: "NotFoundError", params: null }])
 
     const questionRepository = new PrismaQuestionRepository(prisma)

--- a/src/app/api/manage/v1/question/route.ts
+++ b/src/app/api/manage/v1/question/route.ts
@@ -28,7 +28,7 @@ export async function GET(request: NextRequest) {
       new PrismaSchoolRepository(prisma),
     )
     const user = await userService2.getUserInfo(
-      api.getFirebaseUid(),
+      api.getProviderUid(),
       api.getProviderType()!,
     )
     if (!user)
@@ -91,7 +91,7 @@ export async function PATCH(request: NextRequest) {
       new PrismaSchoolRepository(prisma),
     )
     const user = await userService2.getUserInfo(
-      api.getFirebaseUid(),
+      api.getProviderUid(),
       api.getProviderType()!,
     )
     if (!user) throw new ApiV1Error([{ key: "NotFoundError", params: null }])

--- a/src/app/api/manage/v1/user/guest/route.ts
+++ b/src/app/api/manage/v1/user/guest/route.ts
@@ -21,7 +21,10 @@ export async function DELETE(req: NextRequest) {
       new PrismaSchoolRepository(prisma),
     )
 
-    const user = await userService.getUserInfo(api.getFirebaseUid())
+    const user = await userService.getUserInfo(
+      api.getFirebaseUid(),
+      api.getProviderType()!,
+    )
     if (!user) {
       throw new ApiV1Error([{ key: "AuthenticationError", params: null }])
     }

--- a/src/app/api/manage/v1/user/guest/route.ts
+++ b/src/app/api/manage/v1/user/guest/route.ts
@@ -22,7 +22,7 @@ export async function DELETE(req: NextRequest) {
     )
 
     const user = await userService.getUserInfo(
-      api.getFirebaseUid(),
+      api.getProviderUid(),
       api.getProviderType()!,
     )
     if (!user) {

--- a/src/app/api/manage/v1/users/route.ts
+++ b/src/app/api/manage/v1/users/route.ts
@@ -37,7 +37,7 @@ export async function GET(request: NextRequest) {
         )
         return {
           id: u.id,
-          firebaseUid:
+          providerUid:
             emailProvider?.providerUid ?? guestProvider?.providerUid ?? "",
           name: u.name,
           email: u.email,

--- a/src/app/api/manage/v1/users/route.ts
+++ b/src/app/api/manage/v1/users/route.ts
@@ -28,19 +28,30 @@ export async function GET(request: NextRequest) {
       await manageUserService.getUsersForManageAdmin(count, page)
 
     return {
-      users: users.map((u) => ({
-        id: u.id,
-        firebaseUid: u.firebaseUid,
-        name: u.name,
-        email: u.email,
-        phoneNumber: u.phoneNumber,
-        role: u.role,
-        isGuest: u.isGuest,
-        birthDayDate: u.birthDayDate?.toISOString() ?? null,
-        createdAt: u.createdAt.toISOString(),
-        updatedAt: u.updatedAt.toISOString(),
-        deletedAt: u.deletedAt?.toISOString() ?? null,
-      })),
+      users: users.map((u) => {
+        const emailProvider = u.authProviders.find(
+          (p) => p.providerType === "FIREBASE_EMAIL",
+        )
+        const guestProvider = u.authProviders.find(
+          (p) => p.providerType === "FIREBASE_GUEST",
+        )
+        return {
+          id: u.id,
+          firebaseUid:
+            emailProvider?.providerUid ?? guestProvider?.providerUid ?? "",
+          name: u.name,
+          email: u.email,
+          phoneNumber: u.phoneNumber,
+          role: u.role,
+          isGuest: u.authProviders.some(
+            (p) => p.providerType === "FIREBASE_GUEST",
+          ),
+          birthDayDate: u.birthDayDate?.toISOString() ?? null,
+          createdAt: u.createdAt.toISOString(),
+          updatedAt: u.updatedAt.toISOString(),
+          deletedAt: u.deletedAt?.toISOString() ?? null,
+        }
+      }),
       totalCount,
       nextPage,
     }

--- a/src/app/api/user/v1/exercise/question/route.ts
+++ b/src/app/api/user/v1/exercise/question/route.ts
@@ -40,8 +40,11 @@ export async function GET(request: NextRequest) {
         },
       ])
 
-    const userService = new UserService(prisma)
-    await userService.getUserInfo(api.getFirebaseUid())
+      const userService = new UserService(prisma)
+      await userService.getUserInfo(
+        api.getFirebaseUid(),
+        api.getProviderType()!,
+      )
 
     const userQuestionService = new UserQuestionService(
       userService.userController,
@@ -109,8 +112,11 @@ export async function POST(request: NextRequest) {
     const { error, result: body } = validatePost(await request.json())
     if (error) throw error
 
-    const userService = new UserService(prisma)
-    await userService.getUserInfo(api.getFirebaseUid())
+      const userService = new UserService(prisma)
+      await userService.getUserInfo(
+        api.getFirebaseUid(),
+        api.getProviderType()!,
+      )
 
     const userQuestionService = new UserQuestionService(
       userService.userController,
@@ -149,8 +155,11 @@ export async function PATCH(request: NextRequest) {
     const { error, result } = validatePatch(await request.json())
     if (error) throw error
 
-    const userService = new UserService(prisma)
-    await userService.getUserInfo(api.getFirebaseUid())
+      const userService = new UserService(prisma)
+      await userService.getUserInfo(
+        api.getFirebaseUid(),
+        api.getProviderType()!,
+      )
 
     const userQuestionService = new UserQuestionService(
       userService.userController,

--- a/src/app/api/user/v1/exercise/question/route.ts
+++ b/src/app/api/user/v1/exercise/question/route.ts
@@ -42,7 +42,7 @@ export async function GET(request: NextRequest) {
 
       const userService = new UserService(prisma)
       await userService.getUserInfo(
-        api.getFirebaseUid(),
+        api.getProviderUid(),
         api.getProviderType()!,
       )
 
@@ -114,7 +114,7 @@ export async function POST(request: NextRequest) {
 
       const userService = new UserService(prisma)
       await userService.getUserInfo(
-        api.getFirebaseUid(),
+        api.getProviderUid(),
         api.getProviderType()!,
       )
 
@@ -157,7 +157,7 @@ export async function PATCH(request: NextRequest) {
 
       const userService = new UserService(prisma)
       await userService.getUserInfo(
-        api.getFirebaseUid(),
+        api.getProviderUid(),
         api.getProviderType()!,
       )
 

--- a/src/app/api/user/v1/exercise/results/route.ts
+++ b/src/app/api/user/v1/exercise/results/route.ts
@@ -30,7 +30,7 @@ export async function GET(request: NextRequest) {
 
     const userService = new UserService(prisma)
     await userService.getUserInfo(
-      api.getFirebaseUid(),
+      api.getProviderUid(),
       api.getProviderType()!,
     )
 

--- a/src/app/api/user/v1/exercise/results/route.ts
+++ b/src/app/api/user/v1/exercise/results/route.ts
@@ -29,7 +29,10 @@ export async function GET(request: NextRequest) {
     )
 
     const userService = new UserService(prisma)
-    await userService.getUserInfo(api.getFirebaseUid())
+    await userService.getUserInfo(
+      api.getFirebaseUid(),
+      api.getProviderType()!,
+    )
 
     const userQuestionService = new UserQuestionService(
       userService.userController,

--- a/src/app/api/user/v1/exercise/route.ts
+++ b/src/app/api/user/v1/exercise/route.ts
@@ -22,7 +22,7 @@ export function GET(request: NextRequest) {
 
     const userService = new UserService(prisma)
     await userService.getUserInfo(
-      api.getFirebaseUid(),
+      api.getProviderUid(),
       api.getProviderType()!,
     )
     const exerciseService = new ExerciseService(prisma)

--- a/src/app/api/user/v1/exercise/route.ts
+++ b/src/app/api/user/v1/exercise/route.ts
@@ -21,7 +21,10 @@ export function GET(request: NextRequest) {
       ])
 
     const userService = new UserService(prisma)
-    await userService.getUserInfo(api.getFirebaseUid())
+    await userService.getUserInfo(
+      api.getFirebaseUid(),
+      api.getProviderType()!,
+    )
     const exerciseService = new ExerciseService(prisma)
     exerciseService.setUserController(userService.userController)
 

--- a/src/app/api/user/v1/info/route.ts
+++ b/src/app/api/user/v1/info/route.ts
@@ -21,7 +21,7 @@ export async function GET(request: NextRequest) {
       schoolRepository,
     )
     const user = await userService.getUserInfo(
-      api.getFirebaseUid(),
+      api.getProviderUid(),
       api.getProviderType()!,
     )
     if (!user)
@@ -68,7 +68,7 @@ export async function PATCH(request: NextRequest) {
     )
 
     const user = await userService.getUserInfo(
-      api.getFirebaseUid(),
+      api.getProviderUid(),
       api.getProviderType()!,
     )
     if (!user)

--- a/src/app/api/user/v1/info/route.ts
+++ b/src/app/api/user/v1/info/route.ts
@@ -20,7 +20,10 @@ export async function GET(request: NextRequest) {
       userRepository,
       schoolRepository,
     )
-    const user = await userService.getUserInfo(api.getFirebaseUid())
+    const user = await userService.getUserInfo(
+      api.getFirebaseUid(),
+      api.getProviderType()!,
+    )
     if (!user)
       throw new ApiV1Error([{ key: "AuthenticationError", params: null }])
 
@@ -64,7 +67,10 @@ export async function PATCH(request: NextRequest) {
       schoolRepository,
     )
 
-    const user = await userService.getUserInfo(api.getFirebaseUid())
+    const user = await userService.getUserInfo(
+      api.getFirebaseUid(),
+      api.getProviderType()!,
+    )
     if (!user)
       throw new ApiV1Error([{ key: "AuthenticationError", params: null }])
 

--- a/src/app/api/user/v1/login/route.ts
+++ b/src/app/api/user/v1/login/route.ts
@@ -25,7 +25,7 @@ export async function POST(request: NextRequest) {
     )
 
     const user = await userService.getUserInfo(
-      api.getFirebaseUid(),
+      api.getProviderUid(),
       api.getProviderType()!,
     )
 
@@ -100,7 +100,7 @@ export async function POST(request: NextRequest) {
           {
             id: "",
             userId: "",
-            providerUid: api.getFirebaseUid(),
+            providerUid: api.getProviderUid(),
             providerType: api.getProviderType()!,
             createdAt: DateUtility.getNowDate(),
             updatedAt: DateUtility.getNowDate(),

--- a/src/app/api/user/v1/login/route.ts
+++ b/src/app/api/user/v1/login/route.ts
@@ -24,7 +24,10 @@ export async function POST(request: NextRequest) {
       new PrismaSchoolRepository(prisma),
     )
 
-    const user = await userService.getUserInfo(api.getFirebaseUid())
+    const user = await userService.getUserInfo(
+      api.getFirebaseUid(),
+      api.getProviderType()!,
+    )
 
     if (user && !user.isDeleted) {
       return {
@@ -81,11 +84,9 @@ export async function POST(request: NextRequest) {
 
     // ユーザ名はランダムで生成する(今後、ログイン時に登録するようにする)
     const userName = `user-${Math.floor(Math.random() * 10000)}`
-    const isGuest = await api.isGuest()
 
     const newUser = await userService.registerUserInfo(
       new UserEntity({
-        firebaseUid: api.getFirebaseUid(),
         id: "", // IDは自動生成されるため空文字
         name: userName,
         email: email ?? null,
@@ -95,7 +96,16 @@ export async function POST(request: NextRequest) {
         createdAt: DateUtility.getNowDate(),
         updatedAt: DateUtility.getNowDate(),
         deletedAt: null,
-        isGuest,
+        authProviders: [
+          {
+            id: "",
+            userId: "",
+            providerUid: api.getFirebaseUid(),
+            providerType: api.getProviderType()!,
+            createdAt: DateUtility.getNowDate(),
+            updatedAt: DateUtility.getNowDate(),
+          },
+        ],
         memberSchools: [],
         ownerSchools: [],
       }),

--- a/src/app/api/user/v1/quit/route.ts
+++ b/src/app/api/user/v1/quit/route.ts
@@ -25,7 +25,10 @@ export async function POST(request: NextRequest) {
       new PrismaSchoolRepository(prisma),
     )
 
-    const userInfo = await userService.getUserInfo(api.getFirebaseUid())
+    const userInfo = await userService.getUserInfo(
+      api.getFirebaseUid(),
+      api.getProviderType()!,
+    )
     if (!userInfo) {
       throw new ApiV1Error([{ key: "AuthenticationError", params: null }])
     }

--- a/src/app/api/user/v1/quit/route.ts
+++ b/src/app/api/user/v1/quit/route.ts
@@ -26,7 +26,7 @@ export async function POST(request: NextRequest) {
     )
 
     const userInfo = await userService.getUserInfo(
-      api.getFirebaseUid(),
+      api.getProviderUid(),
       api.getProviderType()!,
     )
     if (!userInfo) {

--- a/src/app/api/user/v1/result/log-sheet/route.ts
+++ b/src/app/api/user/v1/result/log-sheet/route.ts
@@ -18,7 +18,10 @@ export async function GET(request: NextRequest) {
       throw new ApiV1Error([{ key: "NotFoundError", params: null }])
 
     const userService = new UserService(prisma)
-    await userService.getUserInfo(api.getFirebaseUid())
+    await userService.getUserInfo(
+      api.getFirebaseUid(),
+      api.getProviderType()!,
+    )
 
     const userQuestionService = new UserQuestionService(
       userService.userController,

--- a/src/app/api/user/v1/result/log-sheet/route.ts
+++ b/src/app/api/user/v1/result/log-sheet/route.ts
@@ -19,7 +19,7 @@ export async function GET(request: NextRequest) {
 
     const userService = new UserService(prisma)
     await userService.getUserInfo(
-      api.getFirebaseUid(),
+      api.getProviderUid(),
       api.getProviderType()!,
     )
 

--- a/src/app/api/user/v1/result/logs/route.ts
+++ b/src/app/api/user/v1/result/logs/route.ts
@@ -18,7 +18,10 @@ export function GET(request: NextRequest) {
     )
 
     const userService = new UserService(prisma)
-    await userService.getUserInfo(api.getFirebaseUid())
+    await userService.getUserInfo(
+      api.getFirebaseUid(),
+      api.getProviderType()!,
+    )
 
     const userQuestionService = new UserQuestionService(
       userService.userController,

--- a/src/app/api/user/v1/result/logs/route.ts
+++ b/src/app/api/user/v1/result/logs/route.ts
@@ -19,7 +19,7 @@ export function GET(request: NextRequest) {
 
     const userService = new UserService(prisma)
     await userService.getUserInfo(
-      api.getFirebaseUid(),
+      api.getProviderUid(),
       api.getProviderType()!,
     )
 

--- a/src/app/api/user/v1/user-config/route.ts
+++ b/src/app/api/user/v1/user-config/route.ts
@@ -11,7 +11,10 @@ export async function GET(request: NextRequest) {
     await api.authorize(request)
     const userService = new UserService(prisma)
 
-    const userInfo = await userService.getUserInfo(api.getFirebaseUid())
+    const userInfo = await userService.getUserInfo(
+      api.getFirebaseUid(),
+      api.getProviderType()!,
+    )
     if (!userInfo)
       throw new ApiV1Error([{ key: "AuthenticationError", params: null }])
 

--- a/src/app/api/user/v1/user-config/route.ts
+++ b/src/app/api/user/v1/user-config/route.ts
@@ -12,7 +12,7 @@ export async function GET(request: NextRequest) {
     const userService = new UserService(prisma)
 
     const userInfo = await userService.getUserInfo(
-      api.getFirebaseUid(),
+      api.getProviderUid(),
       api.getProviderType()!,
     )
     if (!userInfo)

--- a/src/lib/classes/common/ApiV1Wrapper.ts
+++ b/src/lib/classes/common/ApiV1Wrapper.ts
@@ -4,10 +4,11 @@ import { ApiV1OutBase, ApiV1OutTypeMap } from "@/lib/types/apiV1Types"
 import { UserService } from "../services/UserService"
 import { prisma } from "@/lib/prisma"
 import { FirebaseAuthUserRepository } from "../repositories/FirebaseAuthUserRepository"
+import { AuthProviderType } from "@/lib/types/base/authProviderTypes"
 
 export class ApiV1Wrapper {
   private _firebaseUid = ""
-  private _isGuest = false
+  private _providerType: AuthProviderType | null = null
 
   constructor(private apiName: string) {}
 
@@ -55,8 +56,8 @@ export class ApiV1Wrapper {
 
     const firebaseBaseRepo = new FirebaseAuthUserRepository()
     const result = await firebaseBaseRepo.verifyIdToken(token)
-    this._firebaseUid = result.uid
-    this._isGuest = result.isGuest
+    this._firebaseUid = result.providerUid
+    this._providerType = result.providerType
     return result
   }
 
@@ -69,7 +70,10 @@ export class ApiV1Wrapper {
     await this.authorize(request)
 
     const userService = new UserService(prisma)
-    const user = await userService.getUserInfo(this.getFirebaseUid())
+    const user = await userService.getUserInfo(
+      this.getFirebaseUid(),
+      this.getProviderType()!,
+    )
 
     if (!user)
       throw new ApiV1Error([{ key: "AuthenticationError", params: null }])
@@ -81,7 +85,11 @@ export class ApiV1Wrapper {
   }
 
   public async isGuest() {
-    return this._isGuest
+    return this._providerType === "FIREBASE_GUEST"
+  }
+
+  public getProviderType() {
+    return this._providerType
   }
 
   public getFirebaseUid() {

--- a/src/lib/classes/common/ApiV1Wrapper.ts
+++ b/src/lib/classes/common/ApiV1Wrapper.ts
@@ -7,7 +7,7 @@ import { FirebaseAuthUserRepository } from "../repositories/FirebaseAuthUserRepo
 import { AuthProviderType } from "@/lib/types/base/authProviderTypes"
 
 export class ApiV1Wrapper {
-  private _firebaseUid = ""
+  private _providerUid = ""
   private _providerType: AuthProviderType | null = null
 
   constructor(private apiName: string) {}
@@ -56,7 +56,7 @@ export class ApiV1Wrapper {
 
     const firebaseBaseRepo = new FirebaseAuthUserRepository()
     const result = await firebaseBaseRepo.verifyIdToken(token)
-    this._firebaseUid = result.providerUid
+    this._providerUid = result.providerUid
     this._providerType = result.providerType
     return result
   }
@@ -71,7 +71,7 @@ export class ApiV1Wrapper {
 
     const userService = new UserService(prisma)
     const user = await userService.getUserInfo(
-      this.getFirebaseUid(),
+      this.getProviderUid(),
       this.getProviderType()!,
     )
 
@@ -92,7 +92,7 @@ export class ApiV1Wrapper {
     return this._providerType
   }
 
-  public getFirebaseUid() {
-    return this._firebaseUid
+  public getProviderUid() {
+    return this._providerUid
   }
 }

--- a/src/lib/classes/controller/UserController.ts
+++ b/src/lib/classes/controller/UserController.ts
@@ -3,6 +3,7 @@ import {
   UserBaseInfo,
   UserRoleType,
 } from "@/lib/types/base/userTypes"
+import { AuthProviderType } from "@/lib/types/base/authProviderTypes"
 import { ApiV1Error } from "../common/ApiV1Error"
 import { ControllerBase } from "../common/ControllerBase"
 import { SchoolRepository } from "../repositories/SchoolRepository"
@@ -14,27 +15,35 @@ export class UserController extends ControllerBase {
   private _userRole: UserRoleType | null = null
   private _isGuest: boolean = false
 
-  public async getUserInfo(firebaseUid: string) {
-    const user = await this._fetchUserInfoByFirebaseUid(firebaseUid)
+  public async getUserInfo(
+    providerUid: string,
+    providerType: AuthProviderType,
+  ) {
+    const user = await this._fetchUserInfoByAuthProvider(
+      providerUid,
+      providerType,
+    )
     if (!user) return null
 
     this._userId = user.id
     this._userRole = user.role
-    this._isGuest = user.isGuest
+    this._isGuest = user.authProviders.some(
+      (p) => p.providerType === "FIREBASE_GUEST",
+    )
     return user
   }
 
   public async registerUserInfo(
-    firebaseUid: string,
-    isGuest: boolean,
+    providerUid: string,
+    providerType: AuthProviderType,
     data: UserBaseInfo,
   ) {
     return this.dbConnection.$transaction(async (t) => {
       const userRepository = new UserRepository(t)
       const schoolRepository = new SchoolRepository(t)
-      const user = await userRepository.createUserByFirebaseUid(
-        firebaseUid,
-        isGuest,
+      const user = await userRepository.createUserByAuthProvider(
+        providerUid,
+        providerType,
         {
           ...data,
           birthDayDate: null,
@@ -140,9 +149,15 @@ export class UserController extends ControllerBase {
     return await schoolRepository.findMemberSchools(this._userId)
   }
 
-  private async _fetchUserInfoByFirebaseUid(firebaseUid: string) {
+  private async _fetchUserInfoByAuthProvider(
+    providerUid: string,
+    providerType: AuthProviderType,
+  ) {
     const userRepository = new UserRepository(this.dbConnection)
-    return await userRepository.findUserByFirebaseUid(firebaseUid)
+    return await userRepository.findUserByAuthProvider(
+      providerUid,
+      providerType,
+    )
   }
 
   public get userId() {

--- a/src/lib/classes/entities/UserEntity.ts
+++ b/src/lib/classes/entities/UserEntity.ts
@@ -5,9 +5,12 @@ import {
   UserBaseIdentity,
   UserBaseInfo,
   UserBaseInfoOption,
-  UserBaseManageOption,
   UserRoleType,
 } from "@/lib/types/base/userTypes"
+import {
+  AuthProvider,
+  AuthProviderType,
+} from "@/lib/types/base/authProviderTypes"
 import { ApiV1Error } from "../common/ApiV1Error"
 import {
   SchoolBase,
@@ -19,8 +22,8 @@ import { SchoolEntity } from "./SchoolEntity"
 type UserEntityType = UserBaseIdentity &
   UserBaseInfo &
   UserBaseInfoOption &
-  UserBaseDate &
-  UserBaseManageOption & {
+  UserBaseDate & {
+    authProviders: AuthProvider[]
     memberSchools: (SchoolBase & SchoolBaseIdentity & SchoolBaseDate)[]
     ownerSchools: (SchoolBase & SchoolBaseIdentity & SchoolBaseDate)[]
   }
@@ -77,8 +80,26 @@ export class UserEntity extends EntityMutable<UserEntityType> {
     return this.userRole === "ADMIN"
   }
 
+  get authProviders(): AuthProvider[] {
+    return this.value.authProviders
+  }
+
+  public getAuthProvider(providerType: AuthProviderType): AuthProvider | null {
+    return (
+      this.value.authProviders.find(
+        (p) => p.providerType === providerType,
+      ) ?? null
+    )
+  }
+
+  public getAuthProviderUid(providerType: AuthProviderType): string | null {
+    return this.getAuthProvider(providerType)?.providerUid ?? null
+  }
+
   get isGuest(): boolean {
-    return this.value.isGuest
+    return this.value.authProviders.some(
+      (p) => p.providerType === "FIREBASE_GUEST",
+    )
   }
 
   public get isDeleted(): boolean {

--- a/src/lib/classes/repositories/FirebaseAuthUserRepository.ts
+++ b/src/lib/classes/repositories/FirebaseAuthUserRepository.ts
@@ -2,22 +2,28 @@ import { FirebaseAuthError } from "firebase-admin/auth"
 import { firebaseAuth } from "@/lib/functions/firebaseAdmin"
 import { IExternalAuthenticationRepository } from "@/lib/interfaces/IExternalAuthenticationRepository"
 import { ApiV1Error } from "../common/ApiV1Error"
+import { AuthProviderType } from "@/lib/types/base/authProviderTypes"
 
 export class FirebaseAuthUserRepository
   implements IExternalAuthenticationRepository
 {
   async verifyIdToken(idToken: string): Promise<{
-    uid: string
-    isGuest: boolean
+    providerUid: string
+    providerType: AuthProviderType
     email: string | null
     phoneNumber: string | null
   }> {
     try {
       const result = await firebaseAuth().verifyIdToken(idToken)
 
+      const providerType: AuthProviderType =
+        result.firebase.sign_in_provider === "anonymous"
+          ? "FIREBASE_GUEST"
+          : "FIREBASE_EMAIL"
+
       return {
-        uid: result.uid,
-        isGuest: result.firebase.sign_in_provider === "anonymous",
+        providerUid: result.uid,
+        providerType,
         email: result.email ?? null,
         phoneNumber: result.phone_number ?? null,
       }

--- a/src/lib/classes/repositories/PrismaManageDashboardRepository.ts
+++ b/src/lib/classes/repositories/PrismaManageDashboardRepository.ts
@@ -75,7 +75,7 @@ export class PrismaManageDashboardRepository
     return await this.dbConnection.user.count({
       where: {
         deletedAt: null,
-        isGuest: true,
+        authProviders: { some: { providerType: "FIREBASE_GUEST" } },
       },
     })
   }
@@ -86,7 +86,7 @@ export class PrismaManageDashboardRepository
         AND: [
           {
             deletedAt: null,
-            isGuest: true,
+            authProviders: { some: { providerType: "FIREBASE_GUEST" } },
           },
           {
             OR: [

--- a/src/lib/classes/repositories/PrismaManageUserRepository.ts
+++ b/src/lib/classes/repositories/PrismaManageUserRepository.ts
@@ -12,12 +12,13 @@ export class PrismaManageUserRepository
   async findGuestUsersOver5Days(): Promise<UserEntity[]> {
     const users = await this.dbConnection.user.findMany({
       where: {
-        isGuest: true,
+        authProviders: { some: { providerType: "FIREBASE_GUEST" } },
         deletedAt: null,
         createdAt: {
           lt: DateUtility.getBeforeDaysDate(GUEST_USER_DAYS),
         },
       },
+      include: { authProviders: true },
     })
 
     return users.map(
@@ -26,6 +27,7 @@ export class PrismaManageUserRepository
           ...user,
           memberSchools: [],
           ownerSchools: [],
+          authProviders: user.authProviders,
         }),
     )
   }

--- a/src/lib/classes/repositories/PrismaUserRepository.ts
+++ b/src/lib/classes/repositories/PrismaUserRepository.ts
@@ -2,14 +2,22 @@ import { IUserRepository } from "@/lib/interfaces/IUserRepository"
 import { RepositoryBase } from "../common/RepositoryBase"
 import { UserEntity } from "../entities/UserEntity"
 import { DateUtility } from "../common/DateUtility"
+import { AuthProvider } from "@/lib/types/base/authProviderTypes"
 
 export class PrismaUserRepository
   extends RepositoryBase
   implements IUserRepository
 {
-  async findByFirebaseUid(firebaseUid: string): Promise<UserEntity | null> {
-    const user = await this.dbConnection.user.findUnique({
-      where: { firebaseUid },
+  async findByAuthProvider(
+    providerUid: string,
+    providerType: AuthProvider["providerType"],
+  ): Promise<UserEntity | null> {
+    const user = await this.dbConnection.user.findFirst({
+      where: {
+        authProviders: {
+          some: { providerUid, providerType },
+        },
+      },
       include: {
         ownerSchools: {
           select: {
@@ -19,7 +27,9 @@ export class PrismaUserRepository
             OR: [
               {
                 school: { isSelfSchool: true },
-                owner: { firebaseUid },
+                owner: {
+                  authProviders: { some: { providerUid, providerType } },
+                },
               },
             ],
           },
@@ -32,11 +42,15 @@ export class PrismaUserRepository
             OR: [
               { school: { isGlobal: true } },
               {
-                member: { firebaseUid },
+                member: {
+                  authProviders: { some: { providerUid, providerType } },
+                },
                 limitAt: null,
               },
               {
-                member: { firebaseUid },
+                member: {
+                  authProviders: { some: { providerUid, providerType } },
+                },
                 limitAt: {
                   gte: DateUtility.getNowDate(),
                 },
@@ -44,6 +58,7 @@ export class PrismaUserRepository
             ],
           },
         },
+        authProviders: true,
       },
     })
     if (!user) {
@@ -53,18 +68,23 @@ export class PrismaUserRepository
       ...user,
       memberSchools: user.memberSchools.map(({ school }) => school),
       ownerSchools: user.ownerSchools.map(({ school }) => school),
+      authProviders: user.authProviders,
     })
   }
 
   async create(user: UserEntity): Promise<UserEntity> {
     const createdUser = await this.dbConnection.user.create({
       data: {
-        firebaseUid: user.value.firebaseUid,
         name: user.value.name,
         email: user.value.email,
         phoneNumber: user.value.phoneNumber,
         role: user.value.role,
-        isGuest: user.value.isGuest,
+        authProviders: {
+          create: user.value.authProviders.map(({ providerUid, providerType }) => ({
+            providerUid,
+            providerType,
+          })),
+        },
         ownerSchools: {
           create: {
             priority: 1,
@@ -88,16 +108,6 @@ export class PrismaUserRepository
           where: {
             OR: [
               { school: { isGlobal: true } },
-              {
-                member: { firebaseUid: user.value.firebaseUid },
-                limitAt: null,
-              },
-              {
-                member: { firebaseUid: user.value.firebaseUid },
-                limitAt: {
-                  gte: DateUtility.getNowDate(),
-                },
-              },
             ],
           },
         },
@@ -107,21 +117,18 @@ export class PrismaUserRepository
           },
           where: {
             OR: [
-              {
-                school: { isSelfSchool: true },
-                owner: {
-                  firebaseUid: user.value.firebaseUid,
-                },
-              },
+              { school: { isSelfSchool: true } },
             ],
           },
         },
+        authProviders: true,
       },
     })
     return new UserEntity({
       ...createdUser,
       memberSchools: createdUser.memberSchools.map(({ school }) => school),
       ownerSchools: createdUser.ownerSchools.map(({ school }) => school),
+      authProviders: createdUser.authProviders,
     })
   }
 
@@ -134,14 +141,15 @@ export class PrismaUserRepository
         phoneNumber: user.value.phoneNumber,
         role: user.value.role,
         birthDayDate: user.value.birthDayDate,
-        isGuest: user.value.isGuest,
         updatedAt: DateUtility.getNowDate(),
       },
+      include: { authProviders: true },
     })
     return new UserEntity({
       ...updatedUser,
       memberSchools: user.memberSchools.map((s) => s.value),
       ownerSchools: user.ownSchools.map((s) => s.value),
+      authProviders: updatedUser.authProviders,
     })
   }
 
@@ -149,11 +157,13 @@ export class PrismaUserRepository
     const deletedUser = await this.dbConnection.user.update({
       where: { id: user.value.id },
       data: { deletedAt: DateUtility.getNowDate() },
+      include: { authProviders: true },
     })
     return new UserEntity({
       ...deletedUser,
       memberSchools: [],
       ownerSchools: [],
+      authProviders: deletedUser.authProviders,
     })
   }
 
@@ -164,11 +174,13 @@ export class PrismaUserRepository
         deletedAt: null,
         updatedAt: DateUtility.getNowDate(),
       },
+      include: { authProviders: true },
     })
     return new UserEntity({
       ...reRegisteredUser,
       memberSchools: user.memberSchools.map((s) => s.value),
       ownerSchools: user.ownSchools.map((s) => s.value),
+      authProviders: reRegisteredUser.authProviders,
     })
   }
 }

--- a/src/lib/classes/repositories/UserRepository.ts
+++ b/src/lib/classes/repositories/UserRepository.ts
@@ -1,6 +1,7 @@
 // API Route 内で使用するリポジトリクラスを定義する
 
 import { UserBaseInfo, UserBaseInfoOption } from "@/lib/types/base/userTypes"
+import { AuthProviderType } from "@/lib/types/base/authProviderTypes"
 import { RepositoryBase } from "../common/RepositoryBase"
 
 export class UserRepository extends RepositoryBase {
@@ -19,13 +20,12 @@ export class UserRepository extends RepositoryBase {
         birthDayDate: true,
 
         role: true,
-        isGuest: true,
         createdAt: true,
         updatedAt: true,
         deletedAt: true,
 
-        firebaseUid: true,
         ownerSchools: true,
+        authProviders: true,
       },
       take: limit,
       skip: offset,
@@ -57,7 +57,7 @@ export class UserRepository extends RepositoryBase {
         ownerSchools: true,
         createdAt: true,
         updatedAt: true,
-        isGuest: true,
+        authProviders: true,
       },
       where: {
         id: userId,
@@ -65,7 +65,10 @@ export class UserRepository extends RepositoryBase {
     })
   }
 
-  public async findUserByFirebaseUid(firebaseUid: string) {
+  public async findUserByAuthProvider(
+    providerUid: string,
+    providerType: AuthProviderType,
+  ) {
     return await this.dbConnection.user.findFirst({
       select: {
         id: true,
@@ -77,28 +80,32 @@ export class UserRepository extends RepositoryBase {
         ownerSchools: true,
         createdAt: true,
         updatedAt: true,
-        isGuest: true,
+        authProviders: true,
       },
       where: {
-        firebaseUid: firebaseUid,
+        authProviders: { some: { providerUid, providerType } },
       },
     })
   }
 
-  public async createUserByFirebaseUid(
-    firebaseUid: string,
-    isGuest: boolean,
+  public async createUserByAuthProvider(
+    providerUid: string,
+    providerType: AuthProviderType,
     data: UserBaseInfo & UserBaseInfoOption,
   ) {
     return await this.dbConnection.user.create({
       data: {
-        firebaseUid: firebaseUid,
         name: data.name,
         email: data.email,
         phoneNumber: data.phoneNumber,
         birthDayDate: data.birthDayDate || null,
         role: data.role,
-        isGuest: isGuest,
+        authProviders: {
+          create: {
+            providerUid,
+            providerType,
+          },
+        },
       },
     })
   }
@@ -120,13 +127,14 @@ export class UserRepository extends RepositoryBase {
     })
   }
 
-  public async updateUserRoleByFirebaseUid(
-    firebaseUid: string,
+  public async updateUserRoleByAuthProvider(
+    providerUid: string,
+    providerType: AuthProviderType,
     role: UserBaseInfo["role"],
   ) {
     return await this.dbConnection.user.update({
       where: {
-        firebaseUid: firebaseUid,
+        authProviders: { some: { providerUid, providerType } },
       },
       data: {
         role: role,

--- a/src/lib/classes/services/ManageUserService2.ts
+++ b/src/lib/classes/services/ManageUserService2.ts
@@ -4,6 +4,7 @@ import { UserEntity } from "../entities/UserEntity"
 import { IExternalAuthenticationRepository } from "@/lib/interfaces/IExternalAuthenticationRepository"
 import { IManageUserRepository } from "@/lib/interfaces/IManageUserRepository"
 import { PrismaManageUserRepository } from "../repositories/PrismaManageUserRepository"
+import { AuthProviderType } from "@/lib/types/base/authProviderTypes"
 
 /**
  * 管理用ユーザ操作サービスクラス
@@ -38,7 +39,9 @@ export class ManageUserService2 {
     const deletedUserIds = await this._dbConnection.$transaction(async (tx) => {
       // 認証プロバイダ側から削除
       const deletedFromAuthProvider = await this._externalAuthRepo.deleteUsers(
-        guestUsers.map((user) => user.value.firebaseUid),
+        guestUsers.map((user) =>
+          user.getAuthProviderUid(AuthProviderType.FIREBASE_GUEST)!,
+        ),
       )
       if (deletedFromAuthProvider.errors.length > 0) {
         throw new ApiV1Error(

--- a/src/lib/classes/services/UserService.ts
+++ b/src/lib/classes/services/UserService.ts
@@ -1,4 +1,5 @@
 import { EditableUserInfo, UserBaseInfo } from "@/lib/types/base/userTypes"
+import { AuthProviderType } from "@/lib/types/base/authProviderTypes"
 import { ServiceBase } from "../common/ServiceBase"
 import { UserController } from "../controller/UserController"
 import { UserRepository } from "../repositories/UserRepository"
@@ -16,18 +17,21 @@ export class UserService extends ServiceBase {
     this._userController = new UserController(this.dbConnection)
   }
 
-  public async getUserInfo(firebaseUid: string) {
-    return await this._userController.getUserInfo(firebaseUid)
+  public async getUserInfo(
+    providerUid: string,
+    providerType: AuthProviderType,
+  ) {
+    return await this._userController.getUserInfo(providerUid, providerType)
   }
 
   public async registerUserInfo(
-    firebaseUid: string,
-    isGuest: boolean,
+    providerUid: string,
+    providerType: AuthProviderType,
     data: UserBaseInfo,
   ) {
     return await this._userController.registerUserInfo(
-      firebaseUid,
-      isGuest,
+      providerUid,
+      providerType,
       data,
     )
   }

--- a/src/lib/classes/services/UserService2.ts
+++ b/src/lib/classes/services/UserService2.ts
@@ -2,6 +2,7 @@ import { prisma } from "@/lib/prisma"
 import { ISchoolRepository } from "@/lib/interfaces/ISchoolRepository"
 import { IUserRepository } from "@/lib/interfaces/IUserRepository"
 import { EditableUserInfo } from "@/lib/types/base/userTypes"
+import { AuthProviderType } from "@/lib/types/base/authProviderTypes"
 import { PrismaUserRepository } from "../repositories/PrismaUserRepository"
 import { PrismaSchoolRepository } from "../repositories/PrismaSchoolRepository"
 import { UserEntity } from "../entities/UserEntity"
@@ -17,8 +18,14 @@ export class UserService2 {
     private readonly _schoolRepository: ISchoolRepository,
   ) {}
 
-  public async getUserInfo(firebaseUid: string) {
-    return await this._userRepository.findByFirebaseUid(firebaseUid)
+  public async getUserInfo(
+    providerUid: string,
+    providerType: AuthProviderType,
+  ) {
+    return await this._userRepository.findByAuthProvider(
+      providerUid,
+      providerType,
+    )
   }
 
   public async registerUserInfo(userEntity: UserEntity) {

--- a/src/lib/interfaces/IExternalAuthenticationRepository.ts
+++ b/src/lib/interfaces/IExternalAuthenticationRepository.ts
@@ -1,9 +1,11 @@
+import { AuthProviderType } from "@/lib/types/base/authProviderTypes"
+
 export interface IExternalAuthenticationRepository {
   verifyIdToken(
     idToken: string,
   ): Promise<{
-    uid: string
-    isGuest: boolean
+    providerUid: string
+    providerType: AuthProviderType
     email: string | null
     phoneNumber: string | null
   }>

--- a/src/lib/interfaces/IUserRepository.ts
+++ b/src/lib/interfaces/IUserRepository.ts
@@ -1,7 +1,11 @@
 import { UserEntity } from "../classes/entities/UserEntity"
+import { AuthProviderType } from "@/lib/types/base/authProviderTypes"
 
 export interface IUserRepository {
-  findByFirebaseUid(firebaseUid: string): Promise<UserEntity | null>
+  findByAuthProvider(
+    providerUid: string,
+    providerType: AuthProviderType,
+  ): Promise<UserEntity | null>
 
   create(user: UserEntity): Promise<UserEntity>
 

--- a/src/lib/types/base/authProviderTypes.ts
+++ b/src/lib/types/base/authProviderTypes.ts
@@ -1,0 +1,15 @@
+export const AuthProviderType = {
+  FIREBASE_GUEST: "FIREBASE_GUEST",
+  FIREBASE_EMAIL: "FIREBASE_EMAIL",
+} as const
+
+export type AuthProviderType = keyof typeof AuthProviderType
+
+export type AuthProvider = {
+  id: string
+  userId: string
+  providerType: AuthProviderType
+  providerUid: string
+  createdAt: Date
+  updatedAt: Date
+}

--- a/src/lib/types/base/userTypes.ts
+++ b/src/lib/types/base/userTypes.ts
@@ -1,10 +1,13 @@
 import { School } from "./schoolTypes"
+import { AuthProvider } from "./authProviderTypes"
 
 export type User = UserBaseInfo &
   UserBaseInfoOption &
   UserBaseIdentity &
   UserBaseDate &
-  UserRelationSchools
+  UserRelationSchools & {
+    authProviders: AuthProvider[]
+  }
 
 /**
  * 編集可能なユーザ情報項目
@@ -23,14 +26,8 @@ export type UserBaseInfoOption = {
   birthDayDate: Date | null
 }
 
-export type UserBaseManageOption = {
-  isGuest: boolean
-}
-
 export type UserBaseIdentity = {
   id: string
-
-  firebaseUid: string
 }
 
 export type UserBaseDate = {


### PR DESCRIPTION
## 概要
- AuthProviderを複数保持できるようエンティティとリポジトリを整理
- FIREBASE_GUESTの存在でゲスト判定を行うよう各所を修正
- 管理APIのユーザ一覧・ゲスト削除処理を新構造に対応

## テスト
- `npm run lint`
- `npm test` (DATABASE_URL 未設定のため失敗)


------
https://chatgpt.com/codex/tasks/task_e_68874b0616a4833094be5993d70614c3